### PR TITLE
Add DEFAULT_FEATURE constant to replace namespaces

### DIFF
--- a/packages/epics/src/makeEnhancer.js
+++ b/packages/epics/src/makeEnhancer.js
@@ -1,6 +1,7 @@
 import { keys, forEach } from 'ramda';
 import { Subject } from 'rxjs';
 import { createEntries } from '@redux-tools/injectors';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import { epicsInjected, epicsEjected } from './actions';
 import makeRootEpic from './makeRootEpic';
@@ -14,12 +15,12 @@ export default function makeEnhancer({ epicMiddleware, streamCreator }) {
 
 		const rootEpic = makeRootEpic({ inject$, eject$, store, streamCreator });
 
-		store.injectEpics = (epics, { namespace, version, feature = 'namespaces' }) => {
+		store.injectEpics = (epics, { namespace, version, feature = DEFAULT_FEATURE }) => {
 			forEach(entry => inject$.next(entry), createEntries(epics, { namespace, version, feature }));
 			store.dispatch(epicsInjected({ epics: keys(epics), namespace, version, feature }));
 		};
 
-		store.ejectEpics = (epics, { namespace, version, feature = 'namespaces' }) => {
+		store.ejectEpics = (epics, { namespace, version, feature = DEFAULT_FEATURE }) => {
 			forEach(entry => eject$.next(entry), createEntries(epics, { namespace, version, feature }));
 			store.dispatch(epicsEjected({ epics: keys(epics), namespace, version, feature }));
 		};

--- a/packages/epics/src/makeEnhancer.test.js
+++ b/packages/epics/src/makeEnhancer.test.js
@@ -1,4 +1,6 @@
 import { Subject } from 'rxjs';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
+
 import makeEnhancer from './makeEnhancer';
 import { epicsInjected, epicsEjected } from './actions';
 
@@ -30,7 +32,7 @@ describe('makeEnhancer', () => {
 			value: epic,
 			namespace: 'ns',
 			version: 1,
-			feature: 'namespaces',
+			feature: DEFAULT_FEATURE,
 		});
 	});
 
@@ -38,7 +40,12 @@ describe('makeEnhancer', () => {
 		const epic = jest.fn();
 		store.injectEpics({ epic }, { namespace: 'ns', version: 1 });
 		expect(store.dispatch).toHaveBeenCalledWith(
-			epicsInjected({ epics: ['epic'], namespace: 'ns', version: 1, feature: 'namespaces' })
+			epicsInjected({
+				epics: ['epic'],
+				namespace: 'ns',
+				version: 1,
+				feature: DEFAULT_FEATURE,
+			})
 		);
 	});
 
@@ -52,7 +59,7 @@ describe('makeEnhancer', () => {
 			value: epic,
 			namespace: 'ns',
 			version: 1,
-			feature: 'namespaces',
+			feature: DEFAULT_FEATURE,
 		});
 	});
 
@@ -60,7 +67,12 @@ describe('makeEnhancer', () => {
 		const epic = jest.fn();
 		store.ejectEpics({ epic }, { namespace: 'ns', version: 1 });
 		expect(store.dispatch).toHaveBeenCalledWith(
-			epicsEjected({ epics: ['epic'], namespace: 'ns', version: 1, feature: 'namespaces' })
+			epicsEjected({
+				epics: ['epic'],
+				namespace: 'ns',
+				version: 1,
+				feature: DEFAULT_FEATURE,
+			})
 		);
 	});
 

--- a/packages/epics/src/makeRootEpic.test.js
+++ b/packages/epics/src/makeRootEpic.test.js
@@ -2,6 +2,7 @@ import { identity, inc, dec } from 'ramda';
 import { marbles } from 'rxjs-marbles/jest';
 import * as Rx from 'rxjs/operators';
 import { ReplaySubject, Subject, Observable } from 'rxjs';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import makeRootEpic from './makeRootEpic';
 
@@ -70,8 +71,8 @@ describe('makeRootEpic', () => {
 	it(
 		'passes only valid actions to a namespaced epic',
 		marbles(m => {
-			inject$.next({ key: 'id', value: identity, feature: 'namespaces', namespace: 'ns' });
-			const valid = { meta: { feature: 'namespaces', namespace: 'ns' } };
+			inject$.next({ key: 'id', value: identity, feature: DEFAULT_FEATURE, namespace: 'ns' });
+			const valid = { meta: { feature: DEFAULT_FEATURE, namespace: 'ns' } };
 			const invalid = { meta: { namespace: 'wrong' } };
 			const action$ = m.cold('vi', { v: valid, i: invalid });
 			const expected$ = m.cold('v-', { v: valid });

--- a/packages/injectors-react/package.json
+++ b/packages/injectors-react/package.json
@@ -12,6 +12,7 @@
     "Vaclav Jancarik <vaclav.jancarik@lundegaard.eu>"
   ],
   "dependencies": {
+    "@redux-tools/namespaces": "^0.5.0-alpha.3",
     "@redux-tools/utils": "^0.4.0",
     "prop-types": "^15.6.2",
     "ramda": "^0.26.1",

--- a/packages/injectors-react/src/Provider.js
+++ b/packages/injectors-react/src/Provider.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { mergeDeepWith, or, flip } from 'ramda';
 import PropTypes from 'prop-types';
 import { Provider as StoreProvider } from 'react-redux';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import { InjectorContext } from './contexts';
 
@@ -18,7 +19,7 @@ class Provider extends Component {
 	};
 
 	static defaultProps = {
-		feature: 'namespaces',
+		feature: DEFAULT_FEATURE,
 	};
 
 	static contextType = InjectorContext;

--- a/packages/injectors-react/src/Provider.test.js
+++ b/packages/injectors-react/src/Provider.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { identity } from 'ramda';
 import { noop, alwaysNull } from 'ramda-extension';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import Provider from './Provider';
 import { InjectorContext } from './contexts';
@@ -21,7 +22,7 @@ describe('Provider', () => {
 
 		expect(renderProp).toHaveBeenCalledWith({
 			store,
-			features: { namespaces: 'ns' },
+			features: { [DEFAULT_FEATURE]: 'ns' },
 			withNamespace: identity,
 		});
 	});
@@ -41,7 +42,7 @@ describe('Provider', () => {
 
 		expect(renderProp).toHaveBeenCalledWith({
 			store,
-			features: { namespaces: 'yo' },
+			features: { [DEFAULT_FEATURE]: 'yo' },
 			withNamespace: identity,
 		});
 	});
@@ -61,7 +62,7 @@ describe('Provider', () => {
 
 		expect(renderProp).toHaveBeenCalledWith({
 			store,
-			features: { namespaces: 'yo', grids: 'ns' },
+			features: { [DEFAULT_FEATURE]: 'yo', grids: 'ns' },
 			withNamespace: identity,
 		});
 	});
@@ -77,7 +78,7 @@ describe('Provider', () => {
 
 		expect(renderProp).toHaveBeenCalledWith({
 			store,
-			features: { namespaces: 'ns', grids: 'ns-grid' },
+			features: { [DEFAULT_FEATURE]: 'ns', grids: 'ns-grid' },
 			withNamespace: identity,
 		});
 	});

--- a/packages/injectors-react/src/makeInjector.js
+++ b/packages/injectors-react/src/makeInjector.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { omit } from 'ramda';
 import PropTypes from 'prop-types';
 import { getDisplayName } from '@redux-tools/utils';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import withInjectorContext from './withInjectorContext';
 
@@ -11,7 +12,7 @@ makeInjector.resetCounter = () => (counter = 0);
 const omitStore = omit(['store']);
 
 export default function makeInjector(inject, eject) {
-	return (injectables, { persist, global, feature = 'namespaces' } = {}) => NextComponent => {
+	return (injectables, { persist, global, feature = DEFAULT_FEATURE } = {}) => NextComponent => {
 		class Injector extends Component {
 			static propTypes = {
 				namespace: PropTypes.string,

--- a/packages/injectors-react/src/makeInjector.test.js
+++ b/packages/injectors-react/src/makeInjector.test.js
@@ -1,6 +1,7 @@
 import { mount } from 'enzyme';
 import React from 'react';
 import { prop, identity } from 'ramda';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import { InjectorContext } from './contexts';
 import makeInjector from './makeInjector';
@@ -30,7 +31,7 @@ describe('makeInjector', () => {
 
 		expect(store.inject).toHaveBeenCalledWith(
 			{ test: identity },
-			{ feature: 'namespaces', namespace: 'foo', version: 0 }
+			{ feature: DEFAULT_FEATURE, namespace: 'foo', version: 0 }
 		);
 	});
 
@@ -45,7 +46,7 @@ describe('makeInjector', () => {
 		wrapper.unmount();
 		expect(store.eject).toHaveBeenCalledWith(
 			{ test: identity },
-			{ feature: 'namespaces', namespace: 'foo', version: 0 }
+			{ feature: DEFAULT_FEATURE, namespace: 'foo', version: 0 }
 		);
 	});
 

--- a/packages/injectors-react/src/withInjectorContext.js
+++ b/packages/injectors-react/src/withInjectorContext.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import { identity } from 'ramda';
 import { getDisplayName } from '@redux-tools/utils';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import { InjectorContext } from './contexts';
 
-const withInjectorContext = ({ feature = 'namespaces' } = {}) => NextComponent =>
+const withInjectorContext = ({ feature = DEFAULT_FEATURE } = {}) => NextComponent =>
 	class WithInjectorContext extends Component {
 		static displayName = `WithInjectorContext(${getDisplayName(NextComponent)})`;
 

--- a/packages/injectors-react/src/withInjectorContext.test.js
+++ b/packages/injectors-react/src/withInjectorContext.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import { InjectorContext } from './contexts';
 import withInjectorContext from './withInjectorContext';
@@ -55,7 +56,10 @@ describe('withInjectorContext', () => {
 	it('uses namespace with a higher priority than `withNamespace`', () => {
 		const Root = () => null;
 		const WrappedRoot = withInjectorContext()(Root);
-		const contextValue = { features: { namespaces: 'bar' }, withNamespace: withFooNamespace };
+		const contextValue = {
+			features: { [DEFAULT_FEATURE]: 'bar' },
+			withNamespace: withFooNamespace,
+		};
 
 		const wrapper = mount(
 			<InjectorContext.Provider value={contextValue}>
@@ -71,7 +75,7 @@ describe('withInjectorContext', () => {
 		const WrappedRoot = withInjectorContext({ feature: 'grids' })(Root);
 
 		const contextValue = {
-			features: { namespaces: 'bar', grids: 'first-one' },
+			features: { [DEFAULT_FEATURE]: 'bar', grids: 'first-one' },
 			withNamespace: withFooNamespace,
 		};
 
@@ -89,7 +93,7 @@ describe('withInjectorContext', () => {
 		const WrappedRoot = withInjectorContext({ feature: 'grids' })(Root);
 
 		const contextValue = {
-			features: { namespaces: 'bar', grids: 'first-one' },
+			features: { [DEFAULT_FEATURE]: 'bar', grids: 'first-one' },
 			withNamespace: withFooNamespace,
 		};
 

--- a/packages/middleware/src/makeEnhancer.js
+++ b/packages/middleware/src/makeEnhancer.js
@@ -1,6 +1,11 @@
 import { concat, both, reject, keys, map, compose, isEmpty } from 'ramda';
 import { createEntries, isEntryEjectableByVersion, isEntryIncluded } from '@redux-tools/injectors';
-import { isActionFromNamespace, attachNamespace, attachFeature } from '@redux-tools/namespaces';
+import {
+	isActionFromNamespace,
+	attachNamespace,
+	attachFeature,
+	DEFAULT_FEATURE,
+} from '@redux-tools/namespaces';
 
 import { middlewareInjected, middlewareEjected } from './actions';
 
@@ -30,7 +35,7 @@ export default function makeEnhancer() {
 	const enhancer = createStore => (...args) => {
 		const store = createStore(...args);
 
-		store.injectMiddleware = (middleware, { namespace, version, feature = 'namespaces' }) => {
+		store.injectMiddleware = (middleware, { namespace, version, feature = DEFAULT_FEATURE }) => {
 			middlewareEntries = concat(
 				middlewareEntries,
 				createEntries(middleware, { namespace, version, feature })
@@ -48,7 +53,7 @@ export default function makeEnhancer() {
 			store._middlewareEntries = middlewareEntries;
 		};
 
-		store.ejectMiddleware = (middleware, { namespace, version, feature = 'namespaces' }) => {
+		store.ejectMiddleware = (middleware, { namespace, version, feature = DEFAULT_FEATURE }) => {
 			middlewareEntries = reject(
 				both(
 					isEntryEjectableByVersion(version),

--- a/packages/middleware/src/makeEnhancer.test.js
+++ b/packages/middleware/src/makeEnhancer.test.js
@@ -1,5 +1,6 @@
 import { identity, compose } from 'ramda';
 import { createStore as actualCreateStore, applyMiddleware } from 'redux';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import makeEnhancer from './makeEnhancer';
 
@@ -24,14 +25,14 @@ describe('makeEnhancer', () => {
 		store.injectMiddleware({ foo: identity }, { namespace: 'ns', version: 0 });
 
 		expect(store._middlewareEntries).toEqual([
-			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
 		]);
 
 		store.injectMiddleware({ foo: identity }, { namespace: 'ns', version: 1 });
 
 		expect(store._middlewareEntries).toEqual([
-			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
-			{ key: 'foo', value: identity, namespace: 'ns', version: 1, feature: 'namespaces' },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 1, feature: DEFAULT_FEATURE },
 		]);
 	});
 
@@ -44,14 +45,14 @@ describe('makeEnhancer', () => {
 		store.injectMiddleware({ foo: identity }, { namespace: 'ns', version: 0 });
 
 		expect(store._middlewareEntries).toEqual([
-			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
 		]);
 
 		store.injectMiddleware({ bar: identity }, { namespace: 'ns', version: 0 });
 		store.ejectMiddleware({ foo: identity }, { namespace: 'ns', version: 0 });
 
 		expect(store._middlewareEntries).toEqual([
-			{ key: 'bar', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
+			{ key: 'bar', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
 		]);
 	});
 

--- a/packages/namespaces/src/__snapshots__/constants.test.js.snap
+++ b/packages/namespaces/src/__snapshots__/constants.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`constants should not be changed 1`] = `
+Object {
+  "DEFAULT_FEATURE": "namespaces",
+  "__esModule": true,
+}
+`;

--- a/packages/namespaces/src/constants.js
+++ b/packages/namespaces/src/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_FEATURE = 'namespaces';

--- a/packages/namespaces/src/constants.test.js
+++ b/packages/namespaces/src/constants.test.js
@@ -1,0 +1,7 @@
+import * as Constants from './constants';
+
+describe('constants', () => {
+	it('should not be changed', () => {
+		expect(Constants).toMatchSnapshot();
+	});
+});

--- a/packages/namespaces/src/index.js
+++ b/packages/namespaces/src/index.js
@@ -3,3 +3,4 @@ export { default as attachFeature } from './attachFeature';
 export { default as getNamespaceByAction } from './getNamespaceByAction';
 export { default as getFeatureByAction } from './getFeatureByAction';
 export { default as isActionFromNamespace } from './isActionFromNamespace';
+export * from './constants';

--- a/packages/reducers-react/src/namespacedConnect.js
+++ b/packages/reducers-react/src/namespacedConnect.js
@@ -3,13 +3,13 @@ import { compose, cond, apply, __, isNil, T, map, omit } from 'ramda';
 import { alwaysEmptyObject, isFunction, isObject } from 'ramda-extension';
 import { getStateByNamespace } from '@redux-tools/reducers';
 import { withInjectorContext } from '@redux-tools/injectors-react';
-import { attachNamespace, attachFeature } from '@redux-tools/namespaces';
+import { attachNamespace, attachFeature, DEFAULT_FEATURE } from '@redux-tools/namespaces';
 import { connect } from 'react-redux';
 
 export const wrapMapStateToProps = mapStateToProps => (state, ownProps) =>
 	mapStateToProps
 		? mapStateToProps(
-				getStateByNamespace(ownProps.feature || 'namespaces', ownProps.namespace, state),
+				getStateByNamespace(ownProps.feature || DEFAULT_FEATURE, ownProps.namespace, state),
 				ownProps,
 				state
 		  )
@@ -56,7 +56,7 @@ const namespacedConnect = (
 	mapStateToProps,
 	mapDispatchToProps,
 	mergeProps,
-	{ feature = 'namespaces', ...options } = {}
+	{ feature = DEFAULT_FEATURE, ...options } = {}
 ) =>
 	compose(
 		withInjectorContext({ feature }),

--- a/packages/reducers-react/src/namespacedConnect.test.js
+++ b/packages/reducers-react/src/namespacedConnect.test.js
@@ -4,6 +4,7 @@ import * as R_ from 'ramda-extension';
 import { mount } from 'enzyme';
 import { createStore } from 'redux';
 import { Provider } from '@redux-tools/injectors-react';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import namespacedConnect, {
 	wrapMapStateToProps,
@@ -11,7 +12,7 @@ import namespacedConnect, {
 } from './namespacedConnect';
 
 const state = {
-	namespaces: {
+	[DEFAULT_FEATURE]: {
 		foo: { value: 'Foo' },
 		bar: { qux: { value: 'Qux' } },
 	},
@@ -23,7 +24,7 @@ const state = {
 describe('wrapMapStateToProps', () => {
 	it('gets correct state slice', () => {
 		const mapStateToProps = wrapMapStateToProps(R.identity);
-		expect(mapStateToProps(state, { feature: 'namespaces', namespace: 'foo' })).toEqual({
+		expect(mapStateToProps(state, { feature: DEFAULT_FEATURE, namespace: 'foo' })).toEqual({
 			value: 'Foo',
 		});
 	});
@@ -37,14 +38,14 @@ describe('wrapMapStateToProps', () => {
 
 	it('applies passed mapStateToProps', () => {
 		const mapStateToProps = wrapMapStateToProps(R.prop('qux'));
-		expect(mapStateToProps(state, { feature: 'namespaces', namespace: 'bar' })).toEqual({
+		expect(mapStateToProps(state, { feature: DEFAULT_FEATURE, namespace: 'bar' })).toEqual({
 			value: 'Qux',
 		});
 	});
 
 	it('returns an object when mapStateToProps is undefined', () => {
 		const mapStateToProps = wrapMapStateToProps(null);
-		expect(mapStateToProps(state, { feature: 'namespaces', namespace: 'foo' })).toEqual({});
+		expect(mapStateToProps(state, { feature: DEFAULT_FEATURE, namespace: 'foo' })).toEqual({});
 	});
 });
 
@@ -57,13 +58,13 @@ describe('wrapMapDispatchToProps', () => {
 		const dispatch = jest.fn();
 
 		const { actionCreator } = mapDispatchToProps(dispatch, {
-			feature: 'namespaces',
+			feature: DEFAULT_FEATURE,
 			namespace: 'foo',
 		});
 		actionCreator();
 		expect(dispatch).toHaveBeenCalledWith({
 			type: 'TEST',
-			meta: { feature: 'namespaces', namespace: 'foo' },
+			meta: { feature: DEFAULT_FEATURE, namespace: 'foo' },
 		});
 	});
 
@@ -75,13 +76,13 @@ describe('wrapMapDispatchToProps', () => {
 		const dispatch = jest.fn();
 
 		const { actionCreator } = mapDispatchToProps(dispatch, {
-			feature: 'namespaces',
+			feature: DEFAULT_FEATURE,
 			namespace: 'foo',
 		});
 		actionCreator();
 		expect(dispatch).toHaveBeenCalledWith({
 			type: 'TEST',
-			meta: { feature: 'namespaces', namespace: 'foo' },
+			meta: { feature: DEFAULT_FEATURE, namespace: 'foo' },
 		});
 	});
 
@@ -134,7 +135,7 @@ describe('namespacedConnect', () => {
 		wrapper.find(Root).prop('actionCreator')();
 		expect(store.dispatch).toHaveBeenCalledWith({
 			type: 'TEST',
-			meta: { feature: 'namespaces', namespace: 'bar' },
+			meta: { feature: DEFAULT_FEATURE, namespace: 'bar' },
 		});
 	});
 });

--- a/packages/reducers/src/combineReducerEntries.test.js
+++ b/packages/reducers/src/combineReducerEntries.test.js
@@ -1,4 +1,6 @@
 import { o, inc, dec, defaultTo } from 'ramda';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
+
 import combineReducerEntries, { deepCombineReducers } from './combineReducerEntries';
 
 const incReducer = o(inc, defaultTo(0));
@@ -34,24 +36,24 @@ describe('combineReducerEntries', () => {
 
 	it('handles multiple reducers in same namespace', () => {
 		const reducer = combineReducerEntries([
-			{ key: 'foo', value: incReducer, namespace: 'ns', feature: 'namespaces' },
-			{ key: 'bar', value: decReducer, namespace: 'ns', feature: 'namespaces' },
+			{ key: 'foo', value: incReducer, namespace: 'ns', feature: DEFAULT_FEATURE },
+			{ key: 'bar', value: decReducer, namespace: 'ns', feature: DEFAULT_FEATURE },
 		]);
 
 		expect(reducer()).toEqual({
-			namespaces: {
+			[DEFAULT_FEATURE]: {
 				ns: { foo: 1, bar: -1 },
 			},
 		});
 
 		expect(
 			reducer({
-				namespaces: {
+				[DEFAULT_FEATURE]: {
 					ns: { foo: 1, bar: -1 },
 				},
 			})
 		).toEqual({
-			namespaces: {
+			[DEFAULT_FEATURE]: {
 				ns: { foo: 2, bar: -2 },
 			},
 		});
@@ -59,12 +61,12 @@ describe('combineReducerEntries', () => {
 
 	it('handles multiple namespaces', () => {
 		const reducer = combineReducerEntries([
-			{ key: 'foo', value: incReducer, namespace: 'a', feature: 'namespaces' },
-			{ key: 'bar', value: decReducer, namespace: 'b', feature: 'namespaces' },
+			{ key: 'foo', value: incReducer, namespace: 'a', feature: DEFAULT_FEATURE },
+			{ key: 'bar', value: decReducer, namespace: 'b', feature: DEFAULT_FEATURE },
 		]);
 
 		expect(reducer()).toEqual({
-			namespaces: {
+			[DEFAULT_FEATURE]: {
 				a: { foo: 1 },
 				b: { bar: -1 },
 			},
@@ -72,13 +74,13 @@ describe('combineReducerEntries', () => {
 
 		expect(
 			reducer({
-				namespaces: {
+				[DEFAULT_FEATURE]: {
 					a: { foo: 1 },
 					b: { bar: -1 },
 				},
 			})
 		).toEqual({
-			namespaces: {
+			[DEFAULT_FEATURE]: {
 				a: { foo: 2 },
 				b: { bar: -2 },
 			},

--- a/packages/reducers/src/getStateByAction.js
+++ b/packages/reducers/src/getStateByAction.js
@@ -1,8 +1,9 @@
 import { path, o, defaultTo } from 'ramda';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import getStateByNamespace from './getStateByNamespace';
 
-const getFeature = o(defaultTo('namespaces'), path(['meta', 'feature']));
+const getFeature = o(defaultTo(DEFAULT_FEATURE), path(['meta', 'feature']));
 const getNamespace = path(['meta', 'namespace']);
 /**
  * Returns Redux state by action namespace.

--- a/packages/reducers/src/getStateByAction.test.js
+++ b/packages/reducers/src/getStateByAction.test.js
@@ -1,21 +1,25 @@
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
+
 import getStateByAction from './getStateByAction';
 
 const state = {
-	namespaces: {
+	[DEFAULT_FEATURE]: {
 		foo: { value: 'Wassup' },
 	},
 };
 
 describe('getStateByAction', () => {
 	it('retrieves correct state slice when namespace matches', () => {
-		expect(getStateByAction({ meta: { feature: 'namespaces', namespace: 'foo' } }, state)).toEqual({
+		expect(
+			getStateByAction({ meta: { feature: DEFAULT_FEATURE, namespace: 'foo' } }, state)
+		).toEqual({
 			value: 'Wassup',
 		});
 	});
 
 	it('returns undefined when a nonexistent namespace is passed', () => {
 		expect(
-			getStateByAction({ meta: { feature: 'namespaces', namespace: 'bar' } }, state)
+			getStateByAction({ meta: { feature: DEFAULT_FEATURE, namespace: 'bar' } }, state)
 		).toBeUndefined();
 	});
 

--- a/packages/reducers/src/getStateByNamespace.js
+++ b/packages/reducers/src/getStateByNamespace.js
@@ -1,4 +1,5 @@
 import { curry, path } from 'ramda';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 /**
  * Returns Redux state by namespace. Returns undefined if namespace is undefined.
@@ -13,7 +14,7 @@ const getStateByNamespace = curry((feature, namespace, state) => {
 		return undefined;
 	}
 
-	return path([feature || 'namespaces', namespace], state);
+	return path([feature || DEFAULT_FEATURE, namespace], state);
 });
 
 export default getStateByNamespace;

--- a/packages/reducers/src/getStateByNamespace.test.js
+++ b/packages/reducers/src/getStateByNamespace.test.js
@@ -1,23 +1,25 @@
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
+
 import getStateByNamespace from './getStateByNamespace';
 
 const state = {
-	namespaces: {
+	[DEFAULT_FEATURE]: {
 		foo: { value: 'Wassup' },
 	},
 };
 
 describe('getStateByNamespace', () => {
 	it('retrieves correct state slice when namespace matches', () => {
-		expect(getStateByNamespace('namespaces', 'foo', state)).toEqual({
+		expect(getStateByNamespace(DEFAULT_FEATURE, 'foo', state)).toEqual({
 			value: 'Wassup',
 		});
 	});
 
 	it('returns undefined when a nonexistent namespace is passed', () => {
-		expect(getStateByNamespace('namespaces', 'bar', state)).toBeUndefined();
+		expect(getStateByNamespace(DEFAULT_FEATURE, 'bar', state)).toBeUndefined();
 	});
 
 	it('returns undefined when no namespace is passed', () => {
-		expect(getStateByNamespace('namespaces', undefined, state)).toBeUndefined();
+		expect(getStateByNamespace(DEFAULT_FEATURE, undefined, state)).toBeUndefined();
 	});
 });

--- a/packages/reducers/src/makeEnhancer.js
+++ b/packages/reducers/src/makeEnhancer.js
@@ -1,5 +1,6 @@
 import { both, keys, concat, reject, identity } from 'ramda';
 import { createEntries, isEntryEjectableByVersion, isEntryIncluded } from '@redux-tools/injectors';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import { reducersInjected, reducersEjected } from './actions';
 import combineReducerEntries from './combineReducerEntries';
@@ -11,7 +12,7 @@ export default function makeEnhancer() {
 
 		let reducerEntries = [];
 
-		store.injectReducers = (reducers, { namespace, version, feature = 'namespaces' }) => {
+		store.injectReducers = (reducers, { namespace, version, feature = DEFAULT_FEATURE }) => {
 			reducerEntries = concat(
 				reducerEntries,
 				createEntries(reducers, { namespace, version, feature })
@@ -22,7 +23,7 @@ export default function makeEnhancer() {
 			store._reducerEntries = reducerEntries;
 		};
 
-		store.ejectReducers = (reducers, { namespace, version, feature = 'namespaces' }) => {
+		store.ejectReducers = (reducers, { namespace, version, feature = DEFAULT_FEATURE }) => {
 			reducerEntries = reject(
 				both(
 					isEntryEjectableByVersion(version),

--- a/packages/reducers/src/makeEnhancer.test.js
+++ b/packages/reducers/src/makeEnhancer.test.js
@@ -1,4 +1,5 @@
 import { identity } from 'ramda';
+import { DEFAULT_FEATURE } from '@redux-tools/namespaces';
 
 import makeEnhancer from './makeEnhancer';
 
@@ -25,15 +26,15 @@ describe('makeEnhancer', () => {
 
 		expect(store.replaceReducer).toHaveBeenCalledTimes(1);
 		expect(store._reducerEntries).toEqual([
-			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
 		]);
 
 		store.injectReducers({ foo: identity }, { namespace: 'ns', version: 1 });
 
 		expect(store.replaceReducer).toHaveBeenCalledTimes(2);
 		expect(store._reducerEntries).toEqual([
-			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
-			{ key: 'foo', value: identity, namespace: 'ns', version: 1, feature: 'namespaces' },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 1, feature: DEFAULT_FEATURE },
 		]);
 	});
 
@@ -47,7 +48,7 @@ describe('makeEnhancer', () => {
 
 		expect(store.replaceReducer).toHaveBeenCalledTimes(1);
 		expect(store._reducerEntries).toEqual([
-			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
+			{ key: 'foo', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
 		]);
 
 		store.injectReducers({ bar: identity }, { namespace: 'ns', version: 0 });
@@ -55,7 +56,7 @@ describe('makeEnhancer', () => {
 
 		expect(store.replaceReducer).toHaveBeenCalledTimes(3);
 		expect(store._reducerEntries).toEqual([
-			{ key: 'bar', value: identity, namespace: 'ns', version: 0, feature: 'namespaces' },
+			{ key: 'bar', value: identity, namespace: 'ns', version: 0, feature: DEFAULT_FEATURE },
 		]);
 	});
 


### PR DESCRIPTION
I didn't remove any additional defaulting, because without them, the codebase would be too brittle imo (considering that we don't really use any layers of abstraction for this case, as it would be overkill).