### PR TITLE
Allow configurable middlewareAPI

### DIFF
--- a/packages/middleware/src/makeEnhancer.js
+++ b/packages/middleware/src/makeEnhancer.js
@@ -1,17 +1,17 @@
-import { concat, both, reject, keys, map, compose, isEmpty } from 'ramda';
+import { concat, both, reject, keys, map, compose, isEmpty, identity } from 'ramda';
 import { createEntries, isEntryEjectableByVersion, isEntryIncluded } from '@redux-tools/injectors';
 import { isActionFromNamespace, attachNamespace, attachFeature } from '@redux-tools/namespaces';
 
 import { middlewareInjected, middlewareEjected } from './actions';
 
-export default function makeEnhancer() {
+export default function makeEnhancer({ getMiddlewareAPI = identity } = {}) {
 	let middlewareEntries = [];
 
-	const injectedMiddleware = middlewareAPI => next => action => {
+	const injectedMiddleware = ({ getState, dispatch }) => next => action => {
 		const chain = map(
 			({ namespace, value, feature }) => next => action =>
 				isActionFromNamespace(namespace, action)
-					? value(middlewareAPI)(
+					? value(getMiddlewareAPI({ getState, dispatch, action, namespace, feature }))(
 							compose(
 								next,
 								attachFeature(feature),


### PR DESCRIPTION
@tommmyy This will allow us to do e.g.

```js
injectableMiddleware({
  getMiddlewareAPI: ({ getState, dispatch, action }) => ({
    getState,
    dispatch: dispatchedAction =>
      dispatch(mergeDeepLeft(dispatchedAction, { meta: { key: action.key } })),
  })
})
```

or even (similar to as we had it in our previous project)

```js
injectableMiddleware({
  getMiddlewareAPI: ({ getState, dispatch, feature, namespace }) => ({
    getState, dispatch,
    getNamespacedState: () => getStateByNamespace(feature, namespace, getState()),
  })
})
```