### PR TITLE
Fix middleware memoization + config simplification

### DIFF
--- a/packages/injectors-react/src/makeHook.js
+++ b/packages/injectors-react/src/makeHook.js
@@ -14,7 +14,7 @@ const getOtherProps = omit(['isGlobal', 'global', 'isPersistent', 'persist']);
 const makeHook = config => {
 	invariant(isObject(config), 'The injector config is undefined.');
 
-	const { getEject, getEntries, getInject, ejectMethodName, injectMethodName, type } = config;
+	const { getEntries, ejectionKey, injectionKey, type } = config;
 
 	const pascalCaseType = toPascalCase(type);
 	const hookName = `use${pascalCaseType}`;
@@ -35,8 +35,8 @@ const makeHook = config => {
 		const injectorContext = useInjectorContext(feature);
 		const { store } = injectorContext;
 		const namespace = isGlobal ? null : options.namespace || injectorContext.namespace;
-		const inject = getInject(store);
-		const eject = getEject(store);
+		const inject = store[injectionKey];
+		const eject = store[ejectionKey];
 
 		// NOTE: On the server, the injectables should be injected beforehand.
 		const [isInitialized, setIsInitialized] = useState(IS_SERVER);
@@ -101,15 +101,8 @@ const makeHook = config => {
 				);
 			}
 
-			invariant(
-				inject,
-				`'store.${injectMethodName}' is missing. Are you using the enhancer correctly?`
-			);
-
-			invariant(
-				eject,
-				`'store.${ejectMethodName}' is missing. Are you using the enhancer correctly?`
-			);
+			invariant(inject, `'store.${injectionKey}' missing. Are you using the enhancer correctly?`);
+			invariant(eject, `'store.${ejectionKey}' missing. Are you using the enhancer correctly?`);
 
 			inject(injectables, props);
 			setIsInitialized(true);

--- a/packages/injectors/src/enhanceStore.js
+++ b/packages/injectors/src/enhanceStore.js
@@ -16,7 +16,7 @@ const enhanceStore = (prevStore, config, { onEjected = noop, onInjected = noop }
 		'You must pass an injector config as the second argument to `enhanceStore()`'
 	);
 
-	const { injectMethodName, ejectMethodName, getEntries, setEntries, type } = config;
+	const { injectionKey, ejectionKey, getEntries, setEntries, type } = config;
 	const { dispatch = noop } = prevStore;
 	const actionType = toScreamingSnakeCase(type);
 
@@ -48,8 +48,8 @@ const enhanceStore = (prevStore, config, { onEjected = noop, onInjected = noop }
 
 	const nextStore = {
 		...prevStore,
-		[injectMethodName]: inject,
-		[ejectMethodName]: eject,
+		[injectionKey]: inject,
+		[ejectionKey]: eject,
 	};
 
 	setEntries([], nextStore);

--- a/packages/injectors/src/enhanceStore.test.js
+++ b/packages/injectors/src/enhanceStore.test.js
@@ -13,8 +13,9 @@ describe('enhanceStore', () => {
 	});
 
 	it('spreads passed store to new store', () => {
-		const store = enhanceStore({ dispatch: noop }, config);
+		const store = enhanceStore({ dispatch: noop, getState: noop }, config);
 		expect(store.dispatch).toBe(noop);
+		expect(store.getState).toBe(noop);
 	});
 
 	it('sets injection methods based on type', () => {

--- a/packages/injectors/src/makeConfig.js
+++ b/packages/injectors/src/makeConfig.js
@@ -1,24 +1,16 @@
-import { prop, o, path, assocPath } from 'ramda';
+import { curry, o, path } from 'ramda';
 import { defaultToEmptyArray, toPascalCase } from 'ramda-extension';
 import invariant from 'invariant';
 
 const makeConfig = type => {
 	invariant(type, 'The config type must be defined.');
 
-	const injectMethodName = `inject${toPascalCase(type)}`;
-	const ejectMethodName = `eject${toPascalCase(type)}`;
-	const entriesPath = ['entries', type];
-
 	return {
 		type,
-		getInject: prop(injectMethodName),
-		getEject: prop(ejectMethodName),
-		injectMethodName,
-		ejectMethodName,
-		getEntries: o(defaultToEmptyArray, path(entriesPath)),
-		// NOTE: We need to mutate the store and handle missing `store.entries` object.
-		setEntries: (entries, store) =>
-			(store.entries = assocPath(entriesPath, entries, store).entries),
+		injectionKey: `inject${toPascalCase(type)}`,
+		ejectionKey: `eject${toPascalCase(type)}`,
+		getEntries: o(defaultToEmptyArray, path(['entries', type])),
+		setEntries: curry((entries, store) => (store.entries = { ...store.entries, [type]: entries })),
 	};
 };
 

--- a/packages/injectors/src/makeConfig.test.js
+++ b/packages/injectors/src/makeConfig.test.js
@@ -1,5 +1,3 @@
-import { noop } from 'ramda-extension';
-
 import makeConfig from './makeConfig';
 
 describe('makeConfig', () => {
@@ -11,13 +9,11 @@ describe('makeConfig', () => {
 
 	it('passes correct string attributes down', () => {
 		expect(config.type).toBe('things');
-		expect(config.injectMethodName).toBe('injectThings');
-		expect(config.ejectMethodName).toBe('ejectThings');
+		expect(config.injectionKey).toBe('injectThings');
+		expect(config.ejectionKey).toBe('ejectThings');
 	});
 
 	it('passes correct getters down', () => {
-		expect(config.getInject({ injectThings: noop })).toBe(noop);
-		expect(config.getEject({ ejectThings: noop })).toBe(noop);
 		expect(config.getEntries({ entries: { things: ['foo'] } })).toEqual(['foo']);
 		expect(config.getEntries({})).toEqual([]);
 	});

--- a/packages/middleware/src/makeEnhancer.js
+++ b/packages/middleware/src/makeEnhancer.js
@@ -8,7 +8,7 @@ export const config = makeConfig('middleware');
 const makeEnhancer = ({ getMiddlewareAPI = identity } = {}) => {
 	let entries = [];
 
-	const injectedMiddleware = ({ getState, dispatch }) => next => action => {
+	const injectedMiddleware = ({ getState, dispatch }) => {
 		const makeChain = memoizeWithIdentity(
 			o(
 				map(({ namespace, value, ...otherProps }) => next => action =>
@@ -22,10 +22,12 @@ const makeEnhancer = ({ getMiddlewareAPI = identity } = {}) => {
 			)
 		);
 
-		const chain = makeChain(entries);
-		const composableChain = isEmpty(chain) ? [next => action => next(action)] : chain;
+		return next => action => {
+			const chain = makeChain(entries);
+			const composableChain = isEmpty(chain) ? [next => action => next(action)] : chain;
 
-		return compose(...composableChain)(next)(action);
+			return compose(...composableChain)(next)(action);
+		};
 	};
 
 	const enhancer = createStore => (...args) => {


### PR DESCRIPTION
As with the configs, the `getInject` and `getEject` functions were coupled to the "methodName" concept anyway

Closes #59 